### PR TITLE
fix(components): change checkbox, radio buttons to store adapter classes

### DIFF
--- a/src/material-experimental/mdc-checkbox/checkbox.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.ts
@@ -60,26 +60,10 @@ const RIPPLE_ANIMATION_CONFIG: RippleAnimationConfig = {
 /** Singleton check box adapter. */
 class CheckBoxAdapter implements MDCCheckboxAdapter {
 
-  private static _adapter: CheckBoxAdapter;
-
   private _delegate: MatCheckbox;
 
-  private constructor(delegate: MatCheckbox) {
+  constructor(delegate: MatCheckbox) {
     this._delegate = delegate;
-  }
-
-  useDelegate(delegate: MatCheckbox) {
-    if (!this._delegate) {
-      CheckBoxAdapter._adapter = new CheckBoxAdapter(delegate);
-    } else {
-      this._delegate = delegate;
-    }
-
-    return CheckBoxAdapter.getAdapter();
-  }
-
-  static getAdapter() {
-    return CheckBoxAdapter._adapter;
   }
 
   addClass(className: string) {
@@ -117,9 +101,6 @@ class CheckBoxAdapter implements MDCCheckboxAdapter {
     this._delegate.disabled = disabled;
   }
 }
-
-const _singletonCheckboxAdapter = CheckBoxAdapter.getAdapter();
-
 
 @Component({
   selector: 'mat-checkbox',
@@ -289,7 +270,8 @@ export class MatCheckbox implements AfterViewInit, OnDestroy, ControlValueAccess
     // ripple, which we do ourselves instead.
     this.tabIndex = parseInt(tabIndex) || 0;
     this._checkboxFoundation = new MDCCheckboxFoundation(
-      _singletonCheckboxAdapter.useDelegate(this));
+      new CheckBoxAdapter(this)
+    );
 
     this._options = this._options || {};
 

--- a/src/material-experimental/mdc-radio/radio.ts
+++ b/src/material-experimental/mdc-radio/radio.ts
@@ -67,26 +67,10 @@ const RIPPLE_ANIMATION_CONFIG: RippleAnimationConfig = {
 
 class RadioAdapter implements MDCRadioAdapter {
 
-  private static _adapter: RadioAdapter;
-
   private _delegate: MatRadioButton;
 
-  private constructor(delegate: MatRadioButton) {
+  constructor(delegate: MatRadioButton) {
     this._delegate = delegate;
-  }
-
-  useDelegate(delegate: MatRadioButton) {
-    if (!this._delegate) {
-      RadioAdapter._adapter = new RadioAdapter(delegate);
-    } else {
-      this._delegate = delegate;
-    }
-
-    return RadioAdapter.getAdapter();
-  }
-
-  static getAdapter() {
-    return RadioAdapter._adapter;
   }
 
   addClass(className: string) {
@@ -102,8 +86,6 @@ class RadioAdapter implements MDCRadioAdapter {
     }
   }
 }
-
-const _singletonRadioAdapter = RadioAdapter.getAdapter();
 
 /**
  * A group of radio buttons. May contain one or more `<mat-radio-button>` elements.
@@ -156,7 +138,9 @@ export class MatRadioButton extends _MatRadioButtonBase implements AfterViewInit
   /** Configuration for the underlying ripple. */
   _rippleAnimation: RippleAnimationConfig = RIPPLE_ANIMATION_CONFIG;
 
-  _radioFoundation = new MDCRadioFoundation(_singletonRadioAdapter.useDelegate(this));
+  _radioFoundation = new MDCRadioFoundation(
+    new RadioAdapter(this)
+  );
   _classes: {[key: string]: boolean} = {};
 
   constructor(@Optional() @Inject(MAT_RADIO_GROUP) radioGroup: MatRadioGroup,


### PR DESCRIPTION
This PR makes the Singleton implementation of class adapters for ```mdc-checkbox``` and ```mdc-radio``` into class objects that each instance of a checkbox/radio owns, respectively.